### PR TITLE
Delete uploaded assets

### DIFF
--- a/lib/upload.js
+++ b/lib/upload.js
@@ -110,7 +110,7 @@ glob(PUBLIC_ASSETS_SOURCE_DIRECTORY + '/**/*.*', {}, function(error, files) {
           {encoding: 'utf8'}
         );
 
-        console.log('Deleting uploaded assets from slug...')
+        console.log('Deleting uploaded assets from slug...', PUBLIC_ASSETS_SOURCE_DIRECTORY)
         del(PUBLIC_ASSETS_SOURCE_DIRECTORY).then(paths => {
           console.log(`Deleted ${paths.length} files.`)
           process.exit(0);

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -110,8 +110,9 @@ glob(PUBLIC_ASSETS_SOURCE_DIRECTORY + '/**/*.*', {}, function(error, files) {
           {encoding: 'utf8'}
         );
 
-        console.log('Deleting uploaded assets from slug...', PUBLIC_ASSETS_SOURCE_DIRECTORY)
-        del(PUBLIC_ASSETS_SOURCE_DIRECTORY).then(paths => {
+        const delPath = path.resolve(process.cwd(), PUBLIC_ASSETS_SOURCE_DIRECTORY)
+        console.log('Deleting uploaded assets from slug...', delPath)
+        del(delPath).then(paths => {
           console.log(`Deleted ${paths.length} files.`)
           process.exit(0);
         }).catch(err => {

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -6,6 +6,7 @@ var _ = require('lodash');
 var async = require('async');
 var mimeTypes = require('mime-types');
 var shelljs = require('shelljs');
+var del = require('del')
 
 function getEnvVariable(name, fallback) {
   let envVar;
@@ -109,7 +110,15 @@ glob(PUBLIC_ASSETS_SOURCE_DIRECTORY + '/**/*.*', {}, function(error, files) {
           {encoding: 'utf8'}
         );
 
-        process.exit(0);
+        console.log('Deleting uploaded assets from slug...')
+        del(PUBLIC_ASSETS_SOURCE_DIRECTORY).then(paths => {
+          console.log(`Deleted ${paths.length} files.`)
+          process.exit(0);
+        }).catch(err => {
+          console.error('Failed to delete files', err)
+          process.exit(0)
+        })
+
       });
   }
 );

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -111,8 +111,8 @@ glob(PUBLIC_ASSETS_SOURCE_DIRECTORY + '/**/*.*', {}, function(error, files) {
         );
 
         const delPath = path.resolve(process.cwd(), PUBLIC_ASSETS_SOURCE_DIRECTORY)
-        console.log('Deleting uploaded assets from slug...', delPath)
-        del(delPath).then(paths => {
+        console.log('Deleting uploaded assets from slug...', delPath, process.cwd())
+        del('build/static').then(paths => {
           console.log(`Deleted ${paths.length} files.`)
           process.exit(0);
         }).catch(err => {

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -110,10 +110,9 @@ glob(PUBLIC_ASSETS_SOURCE_DIRECTORY + '/**/*.*', {}, function(error, files) {
           {encoding: 'utf8'}
         );
 
-        const delPath = path.resolve(process.cwd(), PUBLIC_ASSETS_SOURCE_DIRECTORY)
-        console.log('Deleting uploaded assets from slug...', delPath, process.cwd())
-        del('build/static').then(paths => {
-          console.log(`Deleted ${paths.length} files.`)
+        console.log('Deleting uploaded assets from slug...', AWS_STATIC_SOURCE_DIRECTORY)
+        del(AWS_STATIC_SOURCE_DIRECTORY).then(paths => {
+          console.log(`Deleted ${paths} files.`)
           process.exit(0);
         }).catch(err => {
           console.error('Failed to delete files', err)

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -110,9 +110,9 @@ glob(PUBLIC_ASSETS_SOURCE_DIRECTORY + '/**/*.*', {}, function(error, files) {
           {encoding: 'utf8'}
         );
 
-        console.log('Deleting uploaded assets from slug...', AWS_STATIC_SOURCE_DIRECTORY)
-        del(AWS_STATIC_SOURCE_DIRECTORY).then(paths => {
-          console.log(`Deleted ${paths} files.`)
+        console.log('Deleting uploaded assets from slug...', PUBLIC_ASSETS_SOURCE_DIRECTORY)
+        del([PUBLIC_ASSETS_SOURCE_DIRECTORY, '!**/_index.html'], {force: true}).then(paths => {
+          console.log(`Deleted ${paths.length} files.`)
           process.exit(0);
         }).catch(err => {
           console.error('Failed to delete files', err)

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "async": "^2.0.1",
     "aws-sdk": "^2.5.0",
+    "del": "^5.0.0",
     "glob": "^7.0.5",
     "lodash": "^4.15.0",
     "mime-types": "^2.1.11",


### PR DESCRIPTION
After uploading to S3, most of the assets are no longer needed in the slug deployed to Heroku, and can slow down or fail builds or scaling when slugs are too large.
This deletes the uploaded files except for the `_index.html` files which may be needed in some instances.
If there are other files we need to keep, we can add them to the exclusions.

I tested this branch on the profiles monorepo and frontier-app-react